### PR TITLE
Fixed dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 	"dependencies": {
 		"apollo-server": "2.11.0",
 		"apollo-server-express": "2.11.0",
-		"arangochair": "git@github.com:tonlabs/arangochair.git",
+		"arangochair": "https://github.com/tonlabs/arangochair.git",
 		"arangojs": "6.14.0",
 		"commander": "5.0.0",
 		"express": "4.17.1",


### PR DESCRIPTION
It's needed if github ssh access isn't configured (https usually works without additional customization).