### PR TITLE
Fix querying messages from account to itself

### DIFF
--- a/src/server/graphql/blockchain/fetchers/messages.ts
+++ b/src/server/graphql/blockchain/fetchers/messages.ts
@@ -213,6 +213,7 @@ export async function resolve_account_messages(
                     direction: "ASC",
                 },
             ],
+            distinctBy: "account_chain_order",
             request: context,
             traceSpan,
             // TODO: shard and complement_messages usage


### PR DESCRIPTION
In `blockchain { account { messages }}` internal messages with src=dst should be shown twice: as InternalOutbound and as InternalInbound.