### PR TITLE
### Fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.51.1] - 2022-04-30
+
+### Fixed
+
+- `rempReceipts` returns internal server error when redis is inaccessible
+- `rempReceipts` subscription terminated q-server if redis disconnected unexpectedly
+
 ## [0.51.0] - 2022-04-30
 
 ### New

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ton-q-server",
-    "version": "0.51.0",
+    "version": "0.51.1",
     "description": "TON Q Server – realtime queries over TON blockchain.",
     "main": "index.js",
     "repository": "git@github.com:tonlabs/ton-q-server.git",

--- a/src/server/data/kv-list-changes.ts
+++ b/src/server/data/kv-list-changes.ts
@@ -66,9 +66,9 @@ export async function startListChangesIterator<T>(
         }
     }
 
-    await pushNext()
     void (async () => {
         try {
+            await pushNext()
             const changesIterator = await provider.subscribe(keys.changesKey)
             iterator.onClose = async () => {
                 if (changesIterator.return) {
@@ -84,7 +84,9 @@ export async function startListChangesIterator<T>(
                 }
             }
         } catch (error) {
-            void iterator.throw(error).then(() => {})
+            void iterator
+                .throw(new Error("Internal server error"))
+                .then(() => {})
         }
     })().then(() => {})
 

--- a/src/server/graphql/remp.ts
+++ b/src/server/graphql/remp.ts
@@ -98,6 +98,7 @@ function rempReceiptsResolver(
     logs: QLogs,
     customProvider?: KVProvider,
 ) {
+    const log = logs.create("remp-redis")
     return {
         subscribe: async (
             _: unknown,
@@ -111,10 +112,7 @@ function rempReceiptsResolver(
             const provider =
                 customProvider ??
                 (await request.ensureShared("remp-redis-provider", async () => {
-                    return redisProvider(
-                        config.redis,
-                        logs.create("remp-redis"),
-                    )
+                    return redisProvider(config.redis, log)
                 }))
             return await startListChangesIterator(
                 provider,


### PR DESCRIPTION
- `rempReceipts` returns internal server error when redis is inaccessible
- `rempReceipts` subscription terminated q-server if redis disconnected unexpectedly