### PR TITLE
FIX: - `in` operator with empty list parameter returned `null` (must …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to this project will be documented in this file.
 
 - `capabilities_flags` companion field to p8 config parameter `capabilities`
 
+### Fixed
+
+- `in` operator with empty list parameter returned `null` (must return `false`)
+- `notIn` operator with empty list parameter returned `null` (must return `true`)
+
 ## [0.53.3] - 2022-09-06
 
 ### Fix
@@ -19,7 +24,7 @@ All notable changes to this project will be documented in this file.
 ### New
 
 - Add new option `--query-max-timeout-arg` or `Q_QUERY_MAX_TIMEOUT_ARG`. \
-  This adds upper boundary for `timeout` pameter in collection API queries. \
+  This adds upper boundary for `timeout` parameter in collection API queries. \
   Default is 24 hours.
 
 ### Improved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- `in` operator with empty list parameter returned `null` (must return `false`)
-- `notIn` operator with empty list parameter returned `null` (must return `true`)
+- `in: []` (empty list) filters now lead to empty query results as expected
+- `notIn: []` (empty list) filters now are ignored as expected
 
 ## [0.53.3] - 2022-09-06
 

--- a/src/__tests__/gen-ql-tests.ts
+++ b/src/__tests__/gen-ql-tests.ts
@@ -523,6 +523,20 @@ test("Generate AQL", () => {
     expect(params.values.v2).toEqual("2")
 
     params.clear()
+    ql = Transaction.filterCondition(params, "doc", {
+        id: { in: [] },
+    })
+    expect(ql).toEqual("FALSE")
+    expect(params.values).toEqual({})
+
+    params.clear()
+    ql = Transaction.filterCondition(params, "doc", {
+        id: { notIn: [] },
+    })
+    expect(ql).toEqual("TRUE")
+    expect(params.values).toEqual({})
+
+    params.clear()
     ql = Transaction.filterCondition(params, "doc", { in_msg: { ne: "1" } })
     expect(ql).toEqual("doc.in_msg != @v1")
     expect(params.values.v1).toEqual("1")

--- a/src/server/filter/filters.ts
+++ b/src/server/filter/filters.ts
@@ -346,6 +346,9 @@ function filterConditionForIn(
     filter: unknown[],
     explainOp?: string,
 ): string | null {
+    if (filter.length === 0) {
+        return "FALSE"
+    }
     const conditions = filter.map(value =>
         filterConditionOp(
             params,
@@ -454,12 +457,13 @@ const scalarIn: QType = {
 
 const scalarNotIn: QType = {
     filterCondition(params, path, filter) {
-        return `NOT (${filterConditionForIn(
+        const inCondition = filterConditionForIn(
             params,
             path,
             filter as unknown as unknown[],
             "!=",
-        )})`
+        )
+        return inCondition === "FALSE" ? "TRUE" : `NOT (${inCondition})`
     },
     returnExpressions(): QReturnExpression[] {
         throw NOT_IMPLEMENTED


### PR DESCRIPTION
…return `false`), `notIn` operator with empty list parameter returned `null` (must return `true`) (SDK-3826)